### PR TITLE
VA-20: Update package configurations to include STT and TTS examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ client.startRecording();
 | Real-time speech transcription                            | Convert text to speech and save as WAV files          |
 | Keyword spotting                                          | Real-time streaming of synthesized speech             |
 | Event-driven architecture                                 | Multiple voice options available                      |
-| Multiple language support (en-US, de-DE, fr-FR, zh-ZH, es-ES, pt-PT)                                                          | Support for different audio formats (LINEAR16, PCM)   |
+| Multiple language support (en_US, de_DE, fr_FR, zh_ZH, es_ES, pt_PT)                                                          | Support for different audio formats (LINEAR16, PCM)   |
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the official JavaScript/TypeScript SDKs for Aiola's voi
 Want to try out the playground? Just clone and run:
 
 ```bash
-npm install
+npm run install:all
 npm run build
 npm run serve
 ```

--- a/examples/stt-demo/package-lock.json
+++ b/examples/stt-demo/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "name": "stt-demo",
       "dependencies": {
-        "@aiola/web-sdk-stt": "latest"
+        "@aiola/web-sdk-stt": "^0.1.4"
       }
     },
     "node_modules/@aiola/web-sdk-stt": {
-      "version": "0.1.0",
-      "resolved": "https://aiola.jfrog.io/artifactory/api/npm/npm/@aiola/web-sdk-stt/-/@aiola/web-sdk-stt-0.1.0.tgz",
-      "integrity": "sha512-iP+0CfcqbSds9THd6gmzxkQ0P+9FDQ7+EMWBERk9ODIinGyPNE+9YzU88oS61Ro1x49QyBfoUJVyDXjhMdX97w==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@aiola/web-sdk-stt/-/web-sdk-stt-0.1.4.tgz",
+      "integrity": "sha512-hMNtzoFBpasBr4pWm6En8XI/Wo/aVE2rYxXdkL8lk1/txrYsCRgDLYWOwt2OFSbdEc33Q/s5VaDhDh3UnnUZjw==",
       "license": "MIT",
       "dependencies": {
         "socket.io-client": "^4.7.4",

--- a/examples/stt-demo/package.json
+++ b/examples/stt-demo/package.json
@@ -2,6 +2,6 @@
   "name": "stt-demo",
   "type": "module",
   "dependencies": {
-    "@aiola/web-sdk-stt": "0.1.0"
+    "@aiola/web-sdk-stt": "0.1.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "name": "@aiola-sdk",
       "workspaces": [
-        "libs/*"
+        "libs/*",
+        "examples/stt-demo",
+        "examples/tts-demo"
       ],
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -20,6 +22,26 @@
         "typescript": "^5.3.3",
         "web-streams-polyfill": "^4.1.0",
         "whatwg-fetch": "^3.6.20"
+      }
+    },
+    "examples/stt-demo": {
+      "dependencies": {
+        "@aiola/web-sdk-stt": "0.1.4"
+      }
+    },
+    "examples/stt-demo/node_modules/@aiola/web-sdk-stt": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@aiola/web-sdk-stt/-/web-sdk-stt-0.1.4.tgz",
+      "integrity": "sha512-hMNtzoFBpasBr4pWm6En8XI/Wo/aVE2rYxXdkL8lk1/txrYsCRgDLYWOwt2OFSbdEc33Q/s5VaDhDh3UnnUZjw==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io-client": "^4.7.4",
+        "tslib": "^2.6.2"
+      }
+    },
+    "examples/tts-demo": {
+      "dependencies": {
+        "@aiola/web-sdk-tts": "1.0.1"
       }
     },
     "libs/stt": {
@@ -6858,6 +6880,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stt-demo": {
+      "resolved": "examples/stt-demo",
+      "link": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7022,6 +7048,10 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tts-demo": {
+      "resolved": "examples/tts-demo",
+      "link": true
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -2,15 +2,18 @@
   "name": "@aiola-sdk",
   "private": true,
   "workspaces": [
-    "libs/*"
+    "libs/*",
+    "examples/stt-demo",
+    "examples/tts-demo"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
-    "type-check": "npm run type-check --workspaces",
+    "install:all": "npm install --workspaces",
+    "build": "npm run build --workspaces --if-present --workspace=libs/stt --workspace=libs/tts",
     "test": "jest",
     "test:watch": "jest --watch",
     "serve": "http-server -p 3000",
-    "reinstall": "npm rm -rf node_modules && npm i",
+    "clean": "find . -name 'node_modules' -type d -prune -exec rm -rf {} +",
+    "reinstall": "npm run clean && npm run install:all",
     "clb": "npm run reinstall && npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
- Added `examples/stt-demo` and `examples/tts-demo` to workspaces in `package.json`.
- Updated dependencies for `@aiola/web-sdk-stt` to version 0.1.4 in `examples/stt-demo/package.json`.
- Modified installation instructions in `README.md` to use `npm run install:all`.
- Updated `package-lock.json` files for both the root and `stt-demo` to reflect new dependencies and versions.